### PR TITLE
Slack integration revisions

### DIFF
--- a/processor/notifications.py
+++ b/processor/notifications.py
@@ -32,6 +32,7 @@ def send_email(recipients: List[str], subject: str, message: str) -> bool:
     logger.info("  sent")
     return True
 
+
 def send_slack_msg(channel_id,bot_key,subject: str, message: str):
     app = App(token=bot_key)
     header = f"*{subject}*" 

--- a/scripts/queue_googlealerts_stories.py
+++ b/scripts/queue_googlealerts_stories.py
@@ -97,8 +97,8 @@ if __name__ == '__main__':
         results_data = prefect_tasks.queue_stories_for_classification_task(projects_list, stories_with_text,
                                                                            data_source_name)
         # 5. send email with results of operations
-        prefect_tasks.send_email_task(results_data, data_source_name, start_time)
-        prefect_tasks.send_slack_message_task(results_data, data_source_name, start_time)
+        prefect_tasks.send_combined_email_task(results_data, data_source_name, start_time)
+        prefect_tasks.send_combined_slack_message_task(results_data, data_source_name, start_time)
 
     # run the whole thing
     flow.run(parameters={

--- a/scripts/queue_newscatcher_stories.py
+++ b/scripts/queue_newscatcher_stories.py
@@ -145,8 +145,8 @@ if __name__ == '__main__':
         results_data = prefect_tasks.queue_stories_for_classification_task(projects_list, stories_with_text,
                                                                            data_source_name)
         # 5. send email with results of operations
-        prefect_tasks.send_email_task(results_data, data_source_name, start_time)
-        prefect_tasks.send_slack_message_task(results_data, data_source_name, start_time)
+        prefect_tasks.send_combined_email_task(results_data, data_source_name, start_time)
+        prefect_tasks.send_combined_slack_message_task(results_data, data_source_name, start_time)
 
     # run the whole thing
     flow.run(parameters={

--- a/scripts/queue_wayback_stories.py
+++ b/scripts/queue_wayback_stories.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 def load_projects_task() -> List[Dict]:
     project_list = projects.load_project_list(force_reload=True, overwrite_last_story=False)
     logger.info("  Found {} projects".format(len(project_list)))
+    #return [p for p in project_list if p['id'] == 166]
     return project_list
 
 
@@ -201,8 +202,8 @@ if __name__ == '__main__':
         results_data = prefect_tasks.queue_stories_for_classification_task(projects_list, stories_with_text,
                                                                            data_source_name)
         # 5. send email with results of operations
-        prefect_tasks.send_email_task(results_data, data_source_name, start_time)
-        prefect_tasks.send_slack_message_task(results_data, data_source_name, start_time)
+        prefect_tasks.send_combined_email_task(results_data, data_source_name, start_time)
+        prefect_tasks.send_combined_slack_message_task(results_data, data_source_name, start_time)
 
     # run the whole thing
     flow.run(parameters={


### PR DESCRIPTION
Builds on  #11 (@adityagurnani22) to centralize the notifications for the two types of data structures they need to support. I named those "combined" (google alerts, newswatcher, wayback machine) and "project list" (media cloud, unposted). This is still a bit duplicative, but at least hides the redundancy within the prefect tasks module.

Going to merge so we can test it tonight, rather than waiting for review