### PR TITLE
Reduce db sessions

### DIFF
--- a/doc/deploying.md
+++ b/doc/deploying.md
@@ -19,6 +19,7 @@ Create the Dokku apps
   * `dokku rabbitmq:create story-processor-q-nc`
   * `dokku rabbitmq:create story-processor-q-wm`
 5. setup a postgres database: `dokku postgres:create story-processor-db`
+  * you might want then connect to it and do something like `alter system set max_connections = 500;` to give the rather inefficient code some extra headroom 
 6. create an app:
   * `dokku apps:create story-processor-nc`
   * `dokku apps:create story-processor-wm`

--- a/processor/__init__.py
+++ b/processor/__init__.py
@@ -101,6 +101,7 @@ SLACK_CHANNEL_ID = os.environ.get('SLACK_CHANNEL_ID', None)
 if SLACK_CHANNEL_ID is None:
     logger.warning("  ⚠️ No CHANNEL_ID env var specified. We won't be sending slack updates.")
 
+
 def get_mc_client() -> mediacloud.api.DirectoryApi:
     """
     A central place to get the Media Cloud client
@@ -143,6 +144,7 @@ def get_email_config() -> Dict:
         from_address=os.environ.get('SMTP_FROM', None),
         notify_emails=os.environ.get('NOTIFY_EMAILS', "").split(",")
     )
+
 
 def get_slack_config() -> Dict:
     return dict(

--- a/processor/database/__init__.py
+++ b/processor/database/__init__.py
@@ -1,0 +1,16 @@
+from sqlalchemy.orm import sessionmaker
+
+from processor import engine
+
+_Session_Maker = None
+
+
+def _get_session_maker() -> sessionmaker:
+    global _Session_Maker
+    if _Session_Maker is None:
+        _Session_Maker = sessionmaker(bind=engine)
+    return _Session_Maker
+
+
+def get_session_maker() -> sessionmaker:
+    return _get_session_maker()

--- a/processor/database/models.py
+++ b/processor/database/models.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
-from sqlalchemy import Column, BigInteger, Integer, DateTime, Float, Boolean, String
+from sqlalchemy import BigInteger, Integer, DateTime, Float, Boolean, String
 from dateutil.parser import parse
 import datetime as dt
 import logging

--- a/processor/database/projects_db.py
+++ b/processor/database/projects_db.py
@@ -1,16 +1,14 @@
-from sqlalchemy.orm import sessionmaker
 import datetime as dt
+from sqlalchemy.orm.session import Session
 
-from processor import engine
 from processor.database.models import ProjectHistory
 
-Session = sessionmaker(bind=engine)
 
-
-def add_history(project_id: int, last_processed_stories_id: int) -> None:
+def add_history(session: Session, project_id: int, last_processed_stories_id: int) -> None:
     """
     We store project history to keep track of the last story we processed for each project. This lets us optimize
     our queries so that we don't re-process stories within a project.
+    :param session:
     :param project_id:
     :param last_processed_stories_id:
     :return:
@@ -21,23 +19,22 @@ def add_history(project_id: int, last_processed_stories_id: int) -> None:
     now = dt.datetime.now()
     p.created_at = now
     p.updated_at = now
-    session = Session()
     session.add(p)
     session.commit()
 
 
-def update_history(project_id: int, last_processed_stories_id: int = None, last_publish_date: dt.datetime = None,
-                   last_url: str = None) -> None:
+def update_history(session: Session, project_id: int, last_processed_stories_id: int = None,
+                   last_publish_date: dt.datetime = None, last_url: str = None) -> None:
     """
     Once we've processed a batch of stories, use this to save in the database the id of the lastest story
     we've processed (so that we don't redo stories we have already done).
+    :param session:
     :param project_id:
     :param last_processed_stories_id:
     :param last_publish_date:
     :param last_url:
     :return:
     """
-    session = Session()
     project_history = session.get(ProjectHistory, project_id) #session.query(ProjectHistory).get(project_id)[update]
     project_history.last_processed_id = last_processed_stories_id
     project_history.last_publish_date = last_publish_date
@@ -46,13 +43,12 @@ def update_history(project_id: int, last_processed_stories_id: int = None, last_
     session.commit()
 
 
-def get_history(project_id: int) -> ProjectHistory:
+def get_history(session: Session, project_id: int) -> ProjectHistory:
     """
     Find out info about the stories we have processed for this project alerady.
+    :param session
     :param project_id:
     :return:
     """
-    session = Session()
     project_history = session.get(ProjectHistory, project_id)
-    session.close()
     return project_history

--- a/processor/projects.py
+++ b/processor/projects.py
@@ -9,6 +9,7 @@ import time
 from processor import FEMINICIDE_API_KEY, VERSION, path_to_log_dir
 import processor.classifiers as classifiers
 import processor.apiclient as apiclient
+import processor.database as database
 import processor.database.projects_db as projects_db
 
 logger = logging.getLogger(__name__)
@@ -57,12 +58,14 @@ def load_project_list(force_reload: bool = False, overwrite_last_story=False, do
         else:
             _all_projects = []
         # update the local history file, which tracks the latest processed_stories_id we've run for each project
-        for project in _all_projects:
-            project_history = projects_db.get_history(project['id'])
-            if (project_history is None) or overwrite_last_story:
-                projects_db.add_history(project['id'], project['latest_processed_stories_id'])
-                logger.info("    added/overwrote {} to local history".format(project['id']))
-            project['local_processed_stories_id'] = projects_db.get_history(project['id']).last_processed_id
+        Session = database.get_session_maker()
+        with Session() as session:
+            for project in _all_projects:
+                project_history = projects_db.get_history(session, project['id'])
+                if (project_history is None) or overwrite_last_story:
+                    projects_db.add_history(session, project['id'], project['latest_processed_stories_id'])
+                    logger.info("    added/overwrote {} to local history".format(project['id']))
+                project['local_processed_stories_id'] = projects_db.get_history(session, project['id']).last_processed_id
         return _all_projects
     except Exception as e:
         # bail completely if we can't load the config file

--- a/processor/test/test_tasks.py
+++ b/processor/test/test_tasks.py
@@ -3,7 +3,8 @@ import json
 import unittest
 
 import processor.tasks as tasks
-from processor import get_mc_client, SOURCE_MEDIA_CLOUD
+import processor.database as database
+from processor import SOURCE_MEDIA_CLOUD
 from processor.test import test_fixture_dir
 from processor.test.test_projects import TEST_EN_PROJECT
 
@@ -24,7 +25,9 @@ class TestTasks(unittest.TestCase):
                 s = json.load(f)
                 s['source'] = SOURCE_MEDIA_CLOUD
                 stories_with_text.append(s)
-        classified_stories = tasks._add_confidence_to_stories(project, stories_with_text)
+        Session = database.get_session_maker()
+        with Session() as session:
+            classified_stories = tasks._add_confidence_to_stories(session, project, stories_with_text)
         assert len(classified_stories) == len(stories_with_text)
         return classified_stories
 

--- a/scripts/queue_googlealerts_stories.py
+++ b/scripts/queue_googlealerts_stories.py
@@ -7,6 +7,7 @@ from prefect import flow, task, get_run_logger
 from urllib.parse import urlparse, parse_qs
 from prefect_dask.task_runners import DaskTaskRunner
 import processor
+import processor.database as database
 import processor.database.projects_db as projects_db
 from processor.classifiers import download_models
 import processor.projects as projects
@@ -46,7 +47,9 @@ def fetch_project_stories_task(project_list: Dict, data_source: str) -> List[Dic
         project_stories = []
         valid_stories = 0
         logger.info("Project {}/{} - {} stories".format(p['id'], p['title'], len(feed.entries)))
-        history = projects_db.get_history(p['id'])
+        Session = database.get_session_maker()
+        with Session() as session:
+            history = projects_db.get_history(session, p['id'])
         for item in feed.entries:
             # only process stories published after the last check we ran?
             #published_date = dateutil.parser.parse(item['published'])

--- a/scripts/queue_newscatcher_stories.py
+++ b/scripts/queue_newscatcher_stories.py
@@ -30,7 +30,7 @@ nc_api_client = newscatcherapi.NewsCatcherApiClient(x_api_key=processor.NEWSCATC
 DaskTaskRunner(
     cluster_kwargs={
         "image": "prefecthq/prefect:latest",
-        "n_workers":WORKER_COUNT,
+        "n_workers": WORKER_COUNT,
     },
 )
 

--- a/scripts/queue_newscatcher_stories.py
+++ b/scripts/queue_newscatcher_stories.py
@@ -10,7 +10,9 @@ import newscatcherapi
 import newscatcherapi.newscatcherapi_exception
 from prefect_dask.task_runners import DaskTaskRunner
 import requests.exceptions
+
 import processor
+import processor.database as database
 import processor.database.projects_db as projects_db
 from processor.classifiers import download_models
 import processor.projects as projects
@@ -77,7 +79,9 @@ def fetch_project_stories_task(project_list: Dict, data_source: str) -> List[Dic
     for p in project_list:
         project_stories = []
         valid_stories = 0
-        history = projects_db.get_history(p['id'])
+        Session = database.get_session_maker()
+        with Session() as session:
+            history = projects_db.get_history(session, p['id'])
         page_number = 1
         # only search stories since the last search (if we've done one before)
         start_date = end_date - dt.timedelta(days=DEFAULT_DAY_WINDOW)

--- a/scripts/queue_unposted_stories.py
+++ b/scripts/queue_unposted_stories.py
@@ -7,6 +7,7 @@ import requests
 import sys
 import time
 from waybacknews.searchapi import SearchApiClient
+import processor.database as database
 import processor.database.stories_db as stories_db
 from processor.classifiers import download_models
 from processor import SOURCE_WAYBACK_MACHINE, SOURCE_NEWSCATCHER
@@ -37,72 +38,74 @@ def load_projects_task() -> List[Dict]:
 @task(name='process_project')
 def process_project_task(project: Dict, page_size: int) -> Dict:
     logger = get_run_logger()
-    project_email_message = ""
-    project_email_message += "Project {} - {}:\n".format(project['id'], project['title'])
-    needing_posting_count = stories_db.unposted_above_story_count(project['id'], DATE_LIMIT)
-    logger.info("Project {} - {} unposted above threshold stories to process".format(
-        project['id'], needing_posting_count))
     story_count = 0
     page_count = 0
-    wm_api = SearchApiClient("mediacloud")
-    if needing_posting_count > 0:
-        db_stories = stories_db.unposted_stories(project['id'], DATE_LIMIT)
-        for db_stories_page in util.chunks(db_stories, page_size):
-            # find the matching story from the source
-            source_stories = []
-            for s in db_stories_page:
-                try:
-                    if s['source'] == SOURCE_WAYBACK_MACHINE:
-                        url_for_query = s['url'].replace("/", "\\/").replace(":", "\\:")
-                        matching_stories = wm_api.sample(f"url:{url_for_query}", dt.datetime(2010, 1, 1),
-                                                         dt.datetime(2030, 1, 1))
-                        matching_story = requests.get(matching_stories[0]['article_url']).json()  # fetch the content (in `snippet`)
-                        matching_story['stories_id'] = s['id']
-                        matching_story['source'] = s['source']
-                        matching_story['media_url'] = matching_story['domain']
-                        matching_story['media_name'] = matching_story['domain']
-                        matching_story['publish_date'] = matching_story['publication_date']
-                        matching_story['log_db_id'] = s['id']
-                        matching_story['project_id'] =s['project_id']
-                        matching_story['language_model_id'] = project['language_model_id']
-                        matching_story['story_text'] = matching_story['snippet']
-                        source_stories += [matching_story]
-                    elif s['source'] == SOURCE_NEWSCATCHER:
-                        metadata = extract(url=s['url'])
-                        story = dict(
-                            stories_id=s['stories_id'],
-                            source=s['source'],
-                            language=metadata['language'],
-                            media_url=metadata['canonical_domain'],
-                            media_name=metadata['canonical_domain'],
-                            publish_date=str(metadata['publication_date']),
-                            title=metadata['article_title'],
-                            url=metadata['url'],  # resolved
-                            log_db_id=s['stories_id'],
-                            project_id=s['project_id'],
-                            language_model_id=project['language_model_id'],
-                            story_text=metadata['text_content']
-                        )
-                        source_stories += [story]
-                except Exception as e:
-                    logger.warning(f"Skipping {s['url']} due to {e}")
-            # add in entities
-            source_stories = add_entities_to_stories(source_stories)
-            # add in the scores from the logging db
-            db_story_2_score = {r['stories_id']: r for r in db_stories_page}
-            for s in source_stories:
-                s['confidence'] = db_story_2_score[s['stories_id']]['model_score']
-                s['model_1_score'] = db_story_2_score[s['stories_id']]['model_1_score']
-                s['model_2_score'] = db_story_2_score[s['stories_id']]['model_2_score']
-            # strip unneeded fields
-            stories_to_send = projects.prep_stories_for_posting(project, source_stories)
-            # send to main server
-            projects.post_results(project, stories_to_send)
-            # and log that we did it
-            stories_db.update_stories_posted_date(stories_to_send)
-            story_count += len(stories_to_send)
-            logger.info("    sent page of {} stories for project {}".format(len(stories_to_send), project['id']))
-            page_count += 1
+    project_email_message = ""
+    Session = database.get_session_maker()
+    with Session as session:
+        project_email_message += "Project {} - {}:\n".format(project['id'], project['title'])
+        needing_posting_count = stories_db.unposted_above_story_count(session, project['id'], DATE_LIMIT)
+        logger.info("Project {} - {} unposted above threshold stories to process".format(
+            project['id'], needing_posting_count))
+        wm_api = SearchApiClient("mediacloud")
+        if needing_posting_count > 0:
+            db_stories = stories_db.unposted_stories(session, project['id'], DATE_LIMIT)
+            for db_stories_page in util.chunks(db_stories, page_size):
+                # find the matching story from the source
+                source_stories = []
+                for s in db_stories_page:
+                    try:
+                        if s['source'] == SOURCE_WAYBACK_MACHINE:
+                            url_for_query = s['url'].replace("/", "\\/").replace(":", "\\:")
+                            matching_stories = wm_api.sample(f"url:{url_for_query}", dt.datetime(2010, 1, 1),
+                                                             dt.datetime(2030, 1, 1))
+                            matching_story = requests.get(matching_stories[0]['article_url']).json()  # fetch the content (in `snippet`)
+                            matching_story['stories_id'] = s['id']
+                            matching_story['source'] = s['source']
+                            matching_story['media_url'] = matching_story['domain']
+                            matching_story['media_name'] = matching_story['domain']
+                            matching_story['publish_date'] = matching_story['publication_date']
+                            matching_story['log_db_id'] = s['id']
+                            matching_story['project_id'] =s['project_id']
+                            matching_story['language_model_id'] = project['language_model_id']
+                            matching_story['story_text'] = matching_story['snippet']
+                            source_stories += [matching_story]
+                        elif s['source'] == SOURCE_NEWSCATCHER:
+                            metadata = extract(url=s['url'])
+                            story = dict(
+                                stories_id=s['stories_id'],
+                                source=s['source'],
+                                language=metadata['language'],
+                                media_url=metadata['canonical_domain'],
+                                media_name=metadata['canonical_domain'],
+                                publish_date=str(metadata['publication_date']),
+                                title=metadata['article_title'],
+                                url=metadata['url'],  # resolved
+                                log_db_id=s['stories_id'],
+                                project_id=s['project_id'],
+                                language_model_id=project['language_model_id'],
+                                story_text=metadata['text_content']
+                            )
+                            source_stories += [story]
+                    except Exception as e:
+                        logger.warning(f"Skipping {s['url']} due to {e}")
+                # add in entities
+                source_stories = add_entities_to_stories(source_stories)
+                # add in the scores from the logging db
+                db_story_2_score = {r['stories_id']: r for r in db_stories_page}
+                for s in source_stories:
+                    s['confidence'] = db_story_2_score[s['stories_id']]['model_score']
+                    s['model_1_score'] = db_story_2_score[s['stories_id']]['model_1_score']
+                    s['model_2_score'] = db_story_2_score[s['stories_id']]['model_2_score']
+                # strip unneeded fields
+                stories_to_send = projects.prep_stories_for_posting(project, source_stories)
+                # send to main server
+                projects.post_results(project, stories_to_send)
+                # and log that we did it
+                stories_db.update_stories_posted_date(session, stories_to_send)
+                story_count += len(stories_to_send)
+                logger.info("    sent page of {} stories for project {}".format(len(stories_to_send), project['id']))
+                page_count += 1
     logger.info("  sent {} stories for project {} total (of {})".format(story_count, project['id'], needing_posting_count))
     #  add a summary to the email we are generating
     project_email_message += "    posted {} stories from db ({} pages)\n\n".format(story_count, page_count)

--- a/scripts/queue_wayback_stories.py
+++ b/scripts/queue_wayback_stories.py
@@ -10,7 +10,9 @@ from prefect import flow, task, get_run_logger, unmapped
 from waybacknews.searchapi import SearchApiClient
 from prefect_dask.task_runners import DaskTaskRunner
 import requests.exceptions
+
 import processor
+import processor.database as database
 import processor.database.projects_db as projects_db
 from processor.classifiers import download_models
 import processor.projects as projects
@@ -114,7 +116,9 @@ def fetch_project_stories_task(project_list: Dict, data_source: str) -> List[Dic
     for p in project_list:
         project_stories = []
         valid_stories = 0
-        history = projects_db.get_history(p['id'])
+        Session = database.get_session_maker()
+        with Session() as session:
+            history = projects_db.get_history(session, p['id'])
         page_number = 1
         # only search stories since the last search (if we've done one before)
         start_date = end_date - dt.timedelta(days=DEFAULT_DAY_OFFSET + DEFAULT_DAY_WINDOW)


### PR DESCRIPTION
Lots of touchpoint in this, which moves session management up the call stack as per [SQL Alchemy guidelines](https://docs.sqlalchemy.org/en/20/orm/session_basics.html#when-do-i-construct-a-session-when-do-i-commit-it-and-when-do-i-close-it), to try and remove the out-of-connections error we are seeing on prod server.