### PR TITLE
feat(sentry_init): Reconfigure sentry initialization

### DIFF
--- a/processor/__init__.py
+++ b/processor/__init__.py
@@ -4,6 +4,7 @@ import sys
 from typing import Dict
 
 import mediacloud.api
+from celery import signals
 from dotenv import load_dotenv
 from sentry_sdk import init
 from sentry_sdk.integrations.logging import ignore_logger
@@ -72,23 +73,31 @@ if BROKER_URL is None:
     BROKER_URL = "db+sqlite:///results.sqlite"
 # logger.info("  Queue at {}".format(BROKER_URL))
 
-SENTRY_DSN = os.environ.get("SENTRY_DSN", None)  # optional
-if SENTRY_DSN:
-    from sentry_sdk.integrations.celery import CeleryIntegration
 
-    init(
-        dsn=SENTRY_DSN,
-        release=VERSION,
-        before_send=before_send,
-        integrations=[CeleryIntegration()],
-    )
-    ignore_logger("scrapy.core.scraper")
-    ignore_logger("scrapy.downloadermiddlewares.retry")
-    ignore_logger("trafilatura.core")
-    ignore_logger("htmldate.utils")
-    logger.info("  SENTRY_DSN: {}".format(SENTRY_DSN))
-# else:
-#    logger.info("  Not logging errors to Sentry")
+@signals.beat_init.connect
+@signals.celeryd_init.connect
+def init_sentry(**kwargs):
+    SENTRY_DSN = os.environ.get("SENTRY_DSN", None)  # optional
+    if SENTRY_DSN:
+        from sentry_sdk.integrations.celery import CeleryIntegration
+
+        init(
+            dsn=SENTRY_DSN,
+            release=VERSION,
+            before_send=before_send,
+            enable_tracing=True,
+            traces_sample_rate=1.0,
+            profiles_sample_rate=1.0,
+            integrations=[CeleryIntegration(monitor_beat_tasks=True)],
+        )
+        ignore_logger("scrapy.core.scraper")
+        ignore_logger("scrapy.downloadermiddlewares.retry")
+        ignore_logger("trafilatura.core")
+        ignore_logger("htmldate.utils")
+        logger.info("  SENTRY_DSN: {}".format(SENTRY_DSN))
+    # else:
+    # logger.info("  Not logging errors to Sentry")
+
 
 FEMINICIDE_API_URL = os.environ.get("FEMINICIDE_API_URL", None)
 if FEMINICIDE_API_URL is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = [
     ".env",
     "processor/database/alembic"
 ]
-select = ["E4", "E7", "E9", "F", "I"]
+lint.select = ["E4", "E7", "E9", "F", "I"]
 
 
 [tool.commitizen]


### PR DESCRIPTION
Reconfigure sentry initialization so periodic tasks can be monitored on Sentry

kept mostly the same logic, just changed initialization into a function, added related monitor options to init, and added celery signals decorators. Paired with branch feat/issue-61, everything related to celery should run smoothly.


