### PR TITLE
feat(celery_signal): Add a pretask to classify and post worker

### DIFF
--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -139,8 +139,9 @@ def queue_stories_for_classification(
                         session, project_stories, p, datasource
                     )
                     if len(project_stories) > 0:  # don't queue up unnecessary tasks
-                        classification_tasks.classify_and_post_worker.delay(
-                            p, project_stories
+                        # For testing, should be modified to delay
+                        classification_tasks.classify_and_post_worker.apply(
+                            args=[], kwargs={"project": p, "stories": project_stories}
                         )
                         # important to write this update now, because we have queued up the task to process these
                         # stories the task queue will manage retrying with the stories if it fails with this batch


### PR DESCRIPTION
Before classify and post worker is called, ensure_model_files finds matching models to project and makes sure we are using the most recent model versions before classification. If not, new models are downloaded.